### PR TITLE
feat: improve large repo handling with filters, validation UX, export safeguards, and provider fix

### DIFF
--- a/src/app/api/tree/route.ts
+++ b/src/app/api/tree/route.ts
@@ -6,7 +6,7 @@ import type { ProviderType } from '@/lib/providers';
 
 export async function POST(req: Request) {
   try {
-    const { url, providerType } = await req.json();
+    const { url, providerType, maxDepth, excludePatterns } = await req.json();
 
     if (!url || typeof url !== 'string') {
       return NextResponse.json({ error: 'Repository URL is required' }, { status: 400 });
@@ -33,7 +33,11 @@ export async function POST(req: Request) {
     const { owner, repo } = provider.parseUrl(url);
     const tree = await provider.fetchTree(owner, repo, token);
 
-    return NextResponse.json({ tree, provider: resolvedProvider });
+    return NextResponse.json({ 
+      tree, 
+      provider: resolvedProvider,
+      filters: { maxDepth, excludePatterns }
+    });
   } catch (error) {
     console.error('[API/TREE]', error);
 

--- a/src/components/generator/output-viewer.tsx
+++ b/src/components/generator/output-viewer.tsx
@@ -14,7 +14,7 @@ import {
   Copy,
   Download,
   FolderTree,
-  Image,
+  Image as ImageIcon,
   ListTree,
   Maximize,
   Minimize,
@@ -72,6 +72,7 @@ interface OutputViewerProps {
   onExportImage: (format: 'png' | 'svg', repoUrl?: string) => void;
   showExportImageMenu: boolean;
   setShowExportImageMenu: (show: boolean | ((v: boolean) => boolean)) => void;
+  isLargeExport: boolean;
   fileTypeData: { name: string; value: number }[];
   languageData: { name: string; percentage: number }[];
   outputRef: React.RefObject<HTMLDivElement | null>;
@@ -103,6 +104,7 @@ export default function OutputViewer({
   onExportImage,
   showExportImageMenu,
   setShowExportImageMenu,
+  isLargeExport,
   fileTypeData,
   languageData,
   outputRef,
@@ -195,23 +197,37 @@ export default function OutputViewer({
                 aria-label="Export Image"
                 className="flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium text-white bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-500 hover:to-purple-500 disabled:opacity-40 disabled:cursor-not-allowed rounded-lg transition-colors"
               >
-                <Image size={12} aria-hidden="true" />
+                <ImageIcon size={12} aria-hidden="true" />
                 <span className="hidden sm:inline">Export Image</span>
                 <ChevronDown size={10} aria-hidden="true" />
               </button>
               {showExportImageMenu && (
-                <div className="absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg py-1 min-w-[120px] z-20">
-                  {(['png', 'svg'] as const).map((fmt) => (
-                    <button
-                      key={fmt}
-                      onClick={() => onExportImage(fmt, repoUrl)}
-                      aria-label={`Save as ${fmt.toUpperCase()}`}
-                      className="w-full text-left px-3.5 py-2 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center gap-2"
-                    >
-                      <Image size={12} className="text-gray-400" aria-hidden="true" />
-                      Save .{fmt.toUpperCase()}
-                    </button>
-                  ))}
+                <div className="absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg py-1 min-w-[160px] z-20">
+                  {(['png', 'svg'] as const).map((fmt) => {
+                    const isPngDisabled = fmt === 'png' && isLargeExport;
+                    return (
+                      <button
+                        key={fmt}
+                        onClick={() => !isPngDisabled && onExportImage(fmt, repoUrl)}
+                        disabled={isPngDisabled}
+                        aria-label={`Save as ${fmt.toUpperCase()}${isPngDisabled ? ' (disabled)' : ''}`}
+                        title={isPngDisabled ? 'PNG export is disabled for large repositories due to browser limitations. Use SVG export instead.' : undefined}
+                        className={`w-full text-left px-3.5 py-2 text-xs transition-colors flex items-center gap-2 ${
+                          isPngDisabled
+                            ? 'text-gray-400 cursor-not-allowed'
+                            : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                        }`}
+                      >
+                        <ImageIcon size={12} className={isPngDisabled ? 'text-gray-300' : 'text-gray-400'} aria-hidden="true" />
+                        Save .{fmt.toUpperCase()}
+                      </button>
+                    );
+                  })}
+                  {isLargeExport && (
+                    <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400 border-t border-gray-100 dark:border-gray-700">
+                      PNG is disabled for large repositories due to browser limitations. Use SVG instead.
+                    </div>
+                  )}
                 </div>
               )}
             </div>

--- a/src/components/generator/repo-meta-footer.tsx
+++ b/src/components/generator/repo-meta-footer.tsx
@@ -1,17 +1,20 @@
-import { File, Folder, Info } from 'lucide-react';
+import { File, Folder, Info, Layers, Filter } from 'lucide-react';
 import { PERFORMANCE_THRESHOLDS, type RepoValidationResult, type EntryCounts } from '@/lib/repo-tree-utils';
 
 interface RepoMetaFooterProps {
   repoValidation: RepoValidationResult | null;
   isEmpty: boolean;
   entryCounts: EntryCounts;
+  maxDepth?: number | null;
+  excludePatterns?: string[];
 }
 
-export default function RepoMetaFooter({ repoValidation, isEmpty, entryCounts }: RepoMetaFooterProps) {
+export default function RepoMetaFooter({ repoValidation, isEmpty, entryCounts, maxDepth, excludePatterns }: RepoMetaFooterProps) {
+  const hasFilters = (maxDepth !== null && maxDepth !== undefined) || (excludePatterns && excludePatterns.length > 0);
   if (!repoValidation || isEmpty) return null;
 
   return (
-    <div className="px-5 sm:px-6 py-3 border-t border-gray-100 dark:border-gray-800 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+    <div className="px-5 sm:px-6 py-3 border-t border-gray-100 dark:border-gray-800 flex flex-wrap items-center justify-between gap-2 text-xs text-gray-500 dark:text-gray-400">
       <div className="flex items-center gap-2">
         <div className="relative group">
           <Info size={11} />
@@ -28,6 +31,22 @@ export default function RepoMetaFooter({ repoValidation, isEmpty, entryCounts }:
         )}
       </div>
       <div className="flex items-center gap-3 sm:gap-4">
+        {hasFilters && (
+          <div className="flex items-center gap-1.5 text-blue-600 dark:text-blue-400">
+            {maxDepth !== null && maxDepth !== undefined && (
+              <div className="flex items-center gap-1">
+                <Layers size={11} />
+                <span>Depth {maxDepth}</span>
+              </div>
+            )}
+            {excludePatterns && excludePatterns.length > 0 && (
+              <div className="flex items-center gap-1">
+                <Filter size={11} />
+                <span>{excludePatterns.length} excluded</span>
+              </div>
+            )}
+          </div>
+        )}
         <div className="flex items-center gap-1">
           <Folder size={12} className="text-blue-500 dark:text-blue-400" />
           <span>{entryCounts.folders.toLocaleString()} folders</span>

--- a/src/components/generator/repo-tree-generator.tsx
+++ b/src/components/generator/repo-tree-generator.tsx
@@ -45,6 +45,7 @@ export default function RepoTreeGenerator() {
     repoValidation,
     showValidationDialog,
     setShowValidationDialog,
+    setAllowLargeRepo,
     hasOutput,
     showInputErrorBorder,
     showStarNote,
@@ -52,6 +53,7 @@ export default function RepoTreeGenerator() {
     setShowDownloadMenu,
     showExportImageMenu,
     setShowExportImageMenu,
+    isLargeExport,
     inputRef,
     outputRef,
     isEmpty,
@@ -74,14 +76,21 @@ export default function RepoTreeGenerator() {
     setExpanded,
     handleUrlChange,
     handleFetchStructure,
+    handleValidateAndGenerate,
     handleRepoSelect,
     handleClearInput,
     validateUrl,
+    maxDepth,
+    setMaxDepth,
+    excludePatternsInput,
+    setExcludePatternsInput,
+    excludePatterns,
   } = state;
 
   const handleValidationContinue = () => {
+    setAllowLargeRepo(true);
     setShowValidationDialog(false);
-    handleFetchStructure(repoUrl, true);
+    handleValidateAndGenerate();
   };
 
   return (
@@ -92,6 +101,8 @@ export default function RepoTreeGenerator() {
         repoValidation={repoValidation}
         onContinue={handleValidationContinue}
         onCancel={() => setShowValidationDialog(false)}
+        maxDepth={maxDepth}
+        excludePatterns={excludePatterns}
       />
 
       <div className="w-full max-w-4xl mx-auto px-4 sm:px-6">
@@ -147,12 +158,16 @@ export default function RepoTreeGenerator() {
               <div className="pb-5 space-y-3">
                 <div className="flex flex-col sm:flex-row gap-2">
                   <div className="relative w-full sm:w-32 flex-shrink-0">
+                    <label htmlFor="repoType" className="sr-only">
+                      Repository provider
+                    </label>
                     <select
+                      id="repoType"
                       value={repoType}
                       onChange={(e) => {
                         const next = e.target.value as ProviderType;
                         setRepoType(next);
-                        if (repoUrl.trim()) setValidation(validateUrl(repoUrl));
+                        if (repoUrl.trim()) setValidation(validateUrl(repoUrl, next));
                       }}
                       className="w-full h-11 pl-3 pr-8 text-sm bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl text-gray-900 dark:text-white appearance-none cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-500 transition-colors"
                     >
@@ -209,6 +224,51 @@ export default function RepoTreeGenerator() {
                     {loading ? 'Generating…' : 'Generate'}
                   </Button>
                 </div>
+
+                <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
+                  <div className="flex items-center gap-2">
+                    <label htmlFor="maxDepth" className="text-xs font-medium text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                      Max Depth
+                    </label>
+                    <select
+                      id="maxDepth"
+                      value={maxDepth ?? ''}
+                      onChange={(e) => setMaxDepth(e.target.value ? parseInt(e.target.value, 10) : null)}
+                      className="h-9 px-2.5 text-xs bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-gray-900 dark:text-white cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-500 transition-colors"
+                    >
+                      <option value="">Unlimited</option>
+                      <option value="1">1</option>
+                      <option value="2">2</option>
+                      <option value="3">3</option>
+                      <option value="4">4</option>
+                      <option value="5">5</option>
+                      <option value="6">6</option>
+                      <option value="7">7</option>
+                      <option value="8">8</option>
+                      <option value="9">9</option>
+                      <option value="10">10</option>
+                    </select>
+                  </div>
+
+                  <div className="flex-1 flex items-center gap-2">
+                    <label htmlFor="excludeItems" className="text-xs font-medium text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                      Exclude
+                    </label>
+                    <input
+                      id="excludeItems"
+                      type="text"
+                      value={excludePatternsInput}
+                      onChange={(e) => setExcludePatternsInput(e.target.value)}
+                      placeholder="node_modules, dist, *.log"
+                      className="flex-1 h-9 px-3 text-xs bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-500 transition-colors"
+                    />
+                    {excludePatterns.length > 0 && (
+                      <span className="text-[10px] text-blue-600 dark:text-blue-400 font-medium">
+                        {excludePatterns.length} pattern{excludePatterns.length !== 1 ? 's' : ''}
+                      </span>
+                    )}
+                  </div>
+                </div>
               </div>
             )}
           </div>
@@ -240,13 +300,20 @@ export default function RepoTreeGenerator() {
               onExportImage={handleExportImage}
               showExportImageMenu={showExportImageMenu}
               setShowExportImageMenu={setShowExportImageMenu}
+              isLargeExport={isLargeExport}
               fileTypeData={fileTypeData}
               languageData={languageData}
               outputRef={outputRef}
             />
           )}
 
-          <RepoMetaFooter repoValidation={repoValidation} isEmpty={isEmpty} entryCounts={entryCounts} />
+          <RepoMetaFooter 
+            repoValidation={repoValidation} 
+            isEmpty={isEmpty} 
+            entryCounts={entryCounts} 
+            maxDepth={maxDepth}
+            excludePatterns={excludePatterns}
+          />
 
           <StarNote show={showStarNote} />
         </div>

--- a/src/components/generator/validation-dialog.tsx
+++ b/src/components/generator/validation-dialog.tsx
@@ -57,7 +57,7 @@ export default function ValidationDialog({
             ))}
             {hasFilters && repoValidation.warnings.length > 0 && (
               <p className="text-xs text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/20 rounded px-2 py-1.5">
-                Filters applied: Max Depth {maxDepth}, {excludePatterns?.length || 0} exclude pattern(s).
+                Filters applied:{maxDepth !== null && maxDepth !== undefined ? ` Max Depth ${maxDepth}` : ''}{maxDepth !== null && maxDepth !== undefined && excludePatterns && excludePatterns.length > 0 ? ',' : ''}{excludePatterns && excludePatterns.length > 0 ? ` ${excludePatterns.length} exclude pattern(s)` : ''}.
               </p>
             )}
             {!hasFilters && repoValidation.warnings.length > 0 && (

--- a/src/components/generator/validation-dialog.tsx
+++ b/src/components/generator/validation-dialog.tsx
@@ -12,6 +12,8 @@ interface ValidationDialogProps {
   repoValidation: RepoValidationResult | null;
   onContinue: () => void;
   onCancel: () => void;
+  maxDepth?: number | null;
+  excludePatterns?: string[];
 }
 
 export default function ValidationDialog({
@@ -20,7 +22,10 @@ export default function ValidationDialog({
   repoValidation,
   onContinue,
   onCancel,
+  maxDepth,
+  excludePatterns,
 }: ValidationDialogProps) {
+  const hasFilters = (maxDepth !== null && maxDepth !== undefined) || (excludePatterns && excludePatterns.length > 0);
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
@@ -50,16 +55,27 @@ export default function ValidationDialog({
                 <AlertDescription className="text-amber-700 dark:text-amber-300 text-sm">{w}</AlertDescription>
               </Alert>
             ))}
+            {hasFilters && repoValidation.warnings.length > 0 && (
+              <p className="text-xs text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/20 rounded px-2 py-1.5">
+                Filters applied: Max Depth {maxDepth}, {excludePatterns?.length || 0} exclude pattern(s).
+              </p>
+            )}
+            {!hasFilters && repoValidation.warnings.length > 0 && (
+              <p className="text-xs text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/20 rounded px-2 py-1.5">
+                Tip: Try setting Max Depth (2-4) or excluding patterns (e.g., node_modules, dist) to reduce output.
+              </p>
+            )}
             <div className="flex gap-2 pt-1">
-              {repoValidation.isValid && (
-                <Button size="sm" onClick={onContinue}>
-                  Continue anyway
-                </Button>
-              )}
+              <Button size="sm" onClick={onContinue}>
+                Continue Anyway
+              </Button>
               <Button variant="outline" size="sm" onClick={onCancel}>
                 Cancel
               </Button>
             </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400 pt-1">
+              Large repositories may take longer and impact performance.
+            </p>
           </div>
         )}
       </DialogContent>

--- a/src/hooks/use-repo-tree-generator-state.ts
+++ b/src/hooks/use-repo-tree-generator-state.ts
@@ -8,11 +8,14 @@ import {
   generateStructure,
   validateRepositoryStructure,
   PERFORMANCE_THRESHOLDS,
+  GITHUB_LIMITS,
   type RepoValidationResult,
   type EntryCounts,
+  type TreeItem,
   countEntries,
+  FilterOptions,
+  filterTreeEntries,
 } from '@/lib/repo-tree-utils';
-import { detectProviderFromUrl } from '@/lib/providers';
 import { convertMapToJson } from '@/lib/utils';
 import type { TreeCustomizationOptions } from '@/types/tree-customization';
 import { saveAs } from 'file-saver';
@@ -70,6 +73,8 @@ export interface RepoTreeGeneratorState {
   repoValidation: RepoValidationResult | null;
   showValidationDialog: boolean;
   setShowValidationDialog: (show: boolean) => void;
+  allowLargeRepo: boolean;
+  setAllowLargeRepo: (allow: boolean) => void;
   copied: boolean;
   expanded: boolean;
   setExpanded: (v: boolean) => void;
@@ -78,6 +83,12 @@ export interface RepoTreeGeneratorState {
   searchTerm: string;
   setSearchTerm: (term: string) => void;
   customizationOptions: TreeCustomizationOptions;
+  maxDepth: number | null;
+  setMaxDepth: (depth: number | null) => void;
+  excludePatterns: string[];
+  setExcludePatterns: (patterns: string[]) => void;
+  excludePatternsInput: string;
+  setExcludePatternsInput: (input: string) => void;
   fileTypeData: { name: string; value: number }[];
   languageData: { name: string; percentage: number }[];
   selectedRepoName: string | null;
@@ -94,9 +105,13 @@ export interface RepoTreeGeneratorState {
   filteredMap: DirectoryMap;
   treeString: string;
   entryCounts: EntryCounts;
-  validateUrl: (url: string) => ValidationError;
+  isLargeExport: boolean;
+  rawTree: TreeItem[];
+  filteredTree: TreeItem[];
+  validateUrl: (url: string, provider?: ProviderType) => ValidationError;
   handleUrlChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   handleFetchStructure: (url?: string, skipValidation?: boolean) => Promise<void>;
+  handleValidateAndGenerate: (skipValidation?: boolean) => Promise<void>;
   handleRepoSelect: (url: string, provider: string) => void;
   copyToClipboard: () => void;
   handleClearInput: () => void;
@@ -114,6 +129,7 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
   const [validation, setValidation] = useState<ValidationError>({ message: '', isError: false });
   const [repoValidation, setRepoValidation] = useState<RepoValidationResult | null>(null);
   const [showValidationDialog, setShowValidationDialog] = useState(false);
+  const [allowLargeRepo, setAllowLargeRepo] = useState(false);
   const [copied, setCopied] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>('ascii');
@@ -125,6 +141,10 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
   const [languageData, setLanguageData] = useState<{ name: string; percentage: number }[]>([]);
   const [selectedRepoName, setSelectedRepoName] = useState<string | null>(null);
   const [showStarNote, setShowStarNote] = useState(false);
+  const [maxDepth, setMaxDepth] = useState<number | null>(null);
+  const [excludePatternsInput, setExcludePatternsInput] = useState('');
+  const [rawTree, setRawTree] = useState<TreeItem[]>([]);
+  const [filteredTree, setFilteredTree] = useState<TreeItem[]>([]);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const outputRef = useRef<HTMLDivElement>(null);
@@ -136,23 +156,19 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
   }, [isAuthenticated]);
 
   useEffect(() => {
-    const detected = detectProviderFromUrl(repoUrl);
-    if (detected) setRepoType(detected);
-  }, [repoUrl]);
-
-  useEffect(() => {
     const saved = localStorage.getItem('lastRepoUrl');
     if (saved) setRepoUrl(saved);
   }, []);
 
   const validateUrl = useCallback(
-    (url: string): ValidationError => {
+    (url: string, provider?: ProviderType): ValidationError => {
       const trimmed = url.trim();
       if (!trimmed) return { message: 'Enter a repository URL', isError: true };
-      if (repoType === 'github' && !/^https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/?$/.test(trimmed)) {
+      const effectiveProvider = provider ?? repoType;
+      if (effectiveProvider === 'github' && !/^https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/?$/.test(trimmed)) {
         return { message: 'Enter a valid GitHub URL', isError: true };
       }
-      if (repoType === 'gitlab' && !/^https?:\/\/gitlab\.com\/[\w./-]+\/[\w.-]+\/?$/.test(trimmed)) {
+      if (effectiveProvider === 'gitlab' && !/^https?:\/\/gitlab\.com\/[\w./-]+\/[\w.-]+\/?$/.test(trimmed)) {
         return { message: 'Enter a valid GitLab URL', isError: true };
       }
       return { message: '', isError: false };
@@ -188,7 +204,12 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
         const res = await fetch('/api/tree', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ url: effectiveUrl, providerType: repoType }),
+          body: JSON.stringify({ 
+            url: effectiveUrl, 
+            providerType: repoType,
+            maxDepth,
+            excludePatterns: excludePatternsInput.split(',').map(p => p.trim()).filter(Boolean)
+          }),
         });
 
         if (currentRequestId !== requestIdRef.current) return;
@@ -208,16 +229,27 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
 
         if (currentRequestId !== requestIdRef.current) return;
 
-        const repoVal = validateRepositoryStructure(tree);
+        setRawTree(tree);
+
+        const excludePatterns = excludePatternsInput.split(',').map(p => p.trim()).filter(Boolean);
+        const filterOptions: FilterOptions = {
+          maxDepth,
+          excludePatterns
+        };
+        
+        const filtered = filterTreeEntries(tree, filterOptions);
+        setFilteredTree(filtered);
+
+        const repoVal = validateRepositoryStructure(filtered);
         setRepoValidation(repoVal);
 
-        if (!skipValidation && (!repoVal.isValid || repoVal.warnings.length > 0)) {
+        if (!skipValidation && !allowLargeRepo && (!repoVal.isValid || repoVal.warnings.length > 0)) {
           setShowValidationDialog(true);
           setLoading(false);
           return;
         }
 
-        const map = generateStructure(tree);
+        const map = generateStructure(tree, filterOptions);
         setStructureMap(map);
         setValidation({ message: '', isError: false });
         localStorage.setItem('lastRepoUrl', effectiveUrl);
@@ -243,7 +275,48 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
         }
       }
     },
-    [repoUrl, repoType, validateUrl]
+    [repoUrl, repoType, validateUrl, maxDepth, excludePatternsInput, allowLargeRepo]
+  );
+
+  const handleValidateAndGenerate = useCallback(
+    async () => {
+      if (filteredTree.length === 0 && rawTree.length > 0) {
+        const excludePatterns = excludePatternsInput.split(',').map(p => p.trim()).filter(Boolean);
+        const filterOptions: FilterOptions = {
+          maxDepth,
+          excludePatterns
+        };
+        
+        const filtered = filterTreeEntries(rawTree, filterOptions);
+        setFilteredTree(filtered);
+        
+        const repoVal = validateRepositoryStructure(filtered);
+        setRepoValidation(repoVal);
+
+        const map = generateStructure(rawTree, filterOptions);
+        setStructureMap(map);
+        setValidation({ message: '', isError: false });
+
+        const { fileTypes, languages } = analyzeRepository(map);
+        setFileTypeData(fileTypes);
+        setLanguageData(languages);
+        setShowValidationDialog(false);
+
+        setTimeout(() => outputRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' }), 150);
+      } else if (filteredTree.length > 0) {
+        const map = generateStructure(rawTree, {
+          maxDepth,
+          excludePatterns: excludePatternsInput.split(',').map(p => p.trim()).filter(Boolean)
+        });
+        setStructureMap(map);
+        setShowValidationDialog(false);
+        
+        const { fileTypes, languages } = analyzeRepository(map);
+        setFileTypeData(fileTypes);
+        setLanguageData(languages);
+      }
+    },
+    [filteredTree, rawTree, maxDepth, excludePatternsInput]
   );
 
   const handleRepoSelect = useCallback(
@@ -253,9 +326,12 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
       const parts = url.replace(/\/$/, '').split('/');
       setSelectedRepoName(parts[parts.length - 1]);
       setStructureMap(new Map());
+      setRawTree([]);
+      setFilteredTree([]);
       setValidation({ message: '', isError: false });
       setRepoValidation(null);
       setSearchTerm('');
+      setAllowLargeRepo(false);
       handleFetchStructure(url, false);
     },
     [handleFetchStructure]
@@ -305,6 +381,7 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
     setRepoValidation(null);
     setValidation({ message: '', isError: false });
     setShowStarNote(false);
+    setAllowLargeRepo(false);
     inputRef.current?.focus();
   }, []);
 
@@ -344,6 +421,10 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
   }, []);
 
   const handleExportImage = useCallback(async (format: 'png' | 'svg', repoUrl?: string) => {
+    if (format === 'png' && repoValidation && (repoValidation.totalEntries > PERFORMANCE_THRESHOLDS.LARGE_REPO_ENTRIES || repoValidation.estimatedSize > GITHUB_LIMITS.MAX_SIZE_BYTES)) {
+      return;
+    }
+
     const sanitizeRepoName = (name: string | null): string => {
       if (!name) return 'repository';
       return name.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
@@ -470,7 +551,7 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
     }
 
     setShowExportImageMenu(false);
-  }, [treeString, selectedRepoName]);
+  }, [treeString, selectedRepoName, repoValidation]);
 
   const isEmpty = structureMap.size === 0;
   const hasOutput = !isEmpty || loading || sourceTab === 'url';
@@ -491,6 +572,8 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
     repoValidation,
     showValidationDialog,
     setShowValidationDialog,
+    allowLargeRepo,
+    setAllowLargeRepo,
     copied,
     expanded,
     setExpanded,
@@ -515,9 +598,19 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
     filteredMap,
     treeString,
     entryCounts: structureMap.size > 0 ? countEntries(structureMap) : { folders: 0, files: 0 },
+    isLargeExport: repoValidation !== null && (repoValidation.totalEntries > PERFORMANCE_THRESHOLDS.LARGE_REPO_ENTRIES || repoValidation.estimatedSize > GITHUB_LIMITS.MAX_SIZE_BYTES),
+    rawTree,
+    filteredTree,
+    maxDepth,
+    setMaxDepth,
+    excludePatterns: excludePatternsInput.split(',').map(p => p.trim()).filter(Boolean),
+    setExcludePatterns: (patterns: string[]) => setExcludePatternsInput(patterns.join(', ')),
+    excludePatternsInput,
+    setExcludePatternsInput,
     validateUrl,
     handleUrlChange,
     handleFetchStructure,
+    handleValidateAndGenerate,
     handleRepoSelect,
     copyToClipboard,
     handleClearInput,

--- a/src/lib/repo-tree-utils.ts
+++ b/src/lib/repo-tree-utils.ts
@@ -49,26 +49,30 @@ export const validateRepositoryStructure = (tree: TreeItem[]): RepoValidationRes
   if (result.estimatedSize > GITHUB_LIMITS.MAX_SIZE_BYTES) {
     result.isValid = false;
     result.errors.push(
-      `Repository exceeds the ${GITHUB_LIMITS.MAX_SIZE_MB}MB size limit. Estimated: ${(result.estimatedSize / (1024 * 1024)).toFixed(1)}MB.`
+      `This repository exceeds GitHub's recommended API limits (${GITHUB_LIMITS.MAX_SIZE_MB}MB). Processing may fail or be incomplete.`
     );
   }
 
-  if (result.totalEntries > PERFORMANCE_THRESHOLDS.MAX_RECOMMENDED_ENTRIES) {
-    result.warnings.push(
-      `Large repository (${result.totalEntries.toLocaleString()} entries). Performance may be affected.`
-    );
-  } else if (result.totalEntries > PERFORMANCE_THRESHOLDS.LARGE_REPO_ENTRIES) {
-    result.warnings.push(
-      `Medium-sized repository (${result.totalEntries.toLocaleString()} entries). Processing may take a moment.`
-    );
+  if (result.errors.length === 0) {
+    if (result.totalEntries > PERFORMANCE_THRESHOLDS.MAX_RECOMMENDED_ENTRIES) {
+      result.warnings.push(
+        `Large repository (${result.totalEntries.toLocaleString()} entries). Performance may be affected.`
+      );
+    } else if (result.totalEntries > PERFORMANCE_THRESHOLDS.LARGE_REPO_ENTRIES) {
+      result.warnings.push(
+        `Medium-sized repository (${result.totalEntries.toLocaleString()} entries). Processing may take a moment.`
+      );
+    }
   }
 
   return result;
 };
 
-export const generateStructure = (tree: TreeItem[]): DirectoryMap => {
+export const generateStructure = (tree: TreeItem[], options?: FilterOptions): DirectoryMap => {
+  const filteredTree = options ? filterTreeEntries(tree, options) : tree;
+  
   const structureMap: DirectoryMap = new Map();
-  const sortedTree = [...tree].sort((a, b) => a.path.localeCompare(b.path));
+  const sortedTree = [...filteredTree].sort((a, b) => a.path.localeCompare(b.path));
 
   for (const item of sortedTree) {
     const parts = item.path.split('/');
@@ -309,6 +313,88 @@ export const countEntries = (map: DirectoryMap): EntryCounts => {
     traverse(value);
   }
   return { folders, files };
+};
+
+export interface FilterOptions {
+  maxDepth: number | null;
+  excludePatterns: string[];
+}
+
+export const getPathDepth = (path: string): number => {
+  return path.split('/').filter(Boolean).length;
+};
+
+const globToRegex = (pattern: string): RegExp => {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.');
+  return new RegExp(`^${escaped}$`, 'i');
+};
+
+export const matchesExclude = (path: string, patterns: string[]): boolean => {
+  if (patterns.length === 0) return false;
+
+  const segments = path.split('/');
+  const pathParts = segments.filter(Boolean);
+  const fileName = pathParts[pathParts.length - 1] || '';
+
+  for (const pattern of patterns) {
+    if (!pattern.trim()) continue;
+
+    const trimmedPattern = pattern.trim();
+    const regex = globToRegex(trimmedPattern);
+
+    if (regex.test(fileName)) return true;
+
+    if (regex.test(segments[0] || '')) return true;
+
+    for (const segment of pathParts) {
+      if (regex.test(segment)) return true;
+    }
+  }
+
+  return false;
+};
+
+export const filterTreeEntries = (
+  tree: TreeItem[],
+  options: FilterOptions
+): TreeItem[] => {
+  const { maxDepth, excludePatterns } = options;
+
+  if (!maxDepth && (!excludePatterns || excludePatterns.length === 0)) {
+    return tree;
+  }
+
+  const excludedDirs = new Set<string>();
+
+  if (excludePatterns.length > 0) {
+    for (const item of tree) {
+      if (item.type === 'tree' && matchesExclude(item.path, excludePatterns)) {
+        excludedDirs.add(item.path);
+      }
+    }
+  }
+
+  return tree.filter((item) => {
+    if (excludePatterns.length > 0) {
+      if (excludedDirs.has(item.path)) {
+        return false;
+      }
+      for (const excludedDir of excludedDirs) {
+        if (item.path.startsWith(excludedDir + '/')) {
+          return false;
+        }
+      }
+    }
+
+    if (maxDepth !== null && getPathDepth(item.path) > maxDepth) {
+      return false;
+    }
+
+    return true;
+  });
 };
 
 const getLanguageFromExtension = (ext: string): string => {

--- a/src/lib/repo-tree-utils.ts
+++ b/src/lib/repo-tree-utils.ts
@@ -379,6 +379,9 @@ export const filterTreeEntries = (
 
   return tree.filter((item) => {
     if (excludePatterns.length > 0) {
+      if (matchesExclude(item.path, excludePatterns)) {
+        return false;
+      }
       if (excludedDirs.has(item.path)) {
         return false;
       }

--- a/src/lib/repo-tree-utils.ts
+++ b/src/lib/repo-tree-utils.ts
@@ -363,7 +363,7 @@ export const filterTreeEntries = (
 ): TreeItem[] => {
   const { maxDepth, excludePatterns } = options;
 
-  if (!maxDepth && (!excludePatterns || excludePatterns.length === 0)) {
+  if (maxDepth === null && (!excludePatterns || excludePatterns.length === 0)) {
     return tree;
   }
 


### PR DESCRIPTION
## Summary

Implemented and refined **large repository handling** in RepoTree, including filtering, validation UX, export safeguards, and a fix for provider-switch validation.

## Main Changes

### 1. Provider Switch Validation Fix

* Fixed validation using **stale `repoType` state**
* Validation now uses the **newly selected provider directly**
* Removed URL-based provider auto-detection
* Ensures dropdown is the **single source of truth**
* Prevents validation errors from lagging one step behind

### 2. Max Depth Support

* Added **Max Depth** control near generator inputs
* Supports bounded depth and **Unlimited**
* Uses path-based filtering before structure generation
* Reduces output size and improves performance

### 3. Exclude Items Support

* Added **Exclude** input for comma-separated patterns
* Supports:

  * exact names
  * segment matches
  * suffix globs (`*.log`)
* Filtering happens **before** structure generation
* Directory exclusions prune full subtrees

### 4. Pre-Structure Filtering Pipeline

* Filtering applied **before** directory map / ASCII generation
* Ensures real performance gains
* Keeps ASCII / Interactive / Analysis views consistent

### 5. Large Repository Validation Flow

* Improved repository size warning modal
* Displays:

  * total entries
  * estimated size
* Added **Continue Anyway** override
* Prevents modal loop via explicit override flag
* Resets correctly on repo change / input clear

### 6. Warning UX Improvements

* Clear priority:

  * exceeds limit → **error only**
  * medium repo → **warning only**
* Removed redundant stacked messages
* Improved copy to communicate risk without blocking

### 7. Export Behavior for Large Repos

* Disabled **PNG export** for large repositories
* Kept **SVG export** enabled
* Added UI guidance:

  * “PNG disabled for large repos. Use SVG.”
* Added defensive guard to prevent PNG execution

### 8. Metadata / Footer Updates

* Repo metadata reflects **filtered output**
* Footer shows repo size and large repo status
* Improves visibility of processing behavior

## Why These Changes Matter

Improves RepoTree for real-world usage by:

* reducing UI lag
* lowering memory usage
* improving output readability
* preventing export failures
* guiding users with better UX

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pre-generation filters (Max Depth and Exclude), improved large‑repo validation, and safer export behavior to speed up RepoTree and reduce failures. Also fixes provider-switch validation, a filter summary UI edge case, and strict null handling for Max Depth.

- **New Features**
  - Added Max Depth (1–10 or Unlimited) and Exclude patterns; filtering runs before structure generation for faster, smaller output and consistent ASCII/interactive/analysis.
  - Validation dialog shows entry counts and estimated size, includes a “Continue Anyway” option, offers tips when no filters, and resets on repo change.
  - PNG export is disabled for large repos with a disabled dropdown option and guidance; SVG remains available with a guard to block PNG execution.
  - Footer reflects filtered output and shows active filters (depth and number of excludes).

- **Bug Fixes**
  - Provider validation now uses the selected provider; removed URL auto-detection to avoid stale state.
  - Fixed UI to correctly summarize filters when only one is active.
  - Max Depth uses strict null checks to correctly treat “Unlimited” (null) and avoid unintended filtering.

<sup>Written for commit ebf805a57321a7b57852352b1aaf493331c235f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

