### PR TITLE
refactor(api): remove unused filter payload from tree route

### DIFF
--- a/src/app/api/tree/route.ts
+++ b/src/app/api/tree/route.ts
@@ -6,7 +6,7 @@ import type { ProviderType } from '@/lib/providers';
 
 export async function POST(req: Request) {
   try {
-    const { url, providerType, maxDepth, excludePatterns } = await req.json();
+    const { url, providerType } = await req.json();
 
     if (!url || typeof url !== 'string') {
       return NextResponse.json({ error: 'Repository URL is required' }, { status: 400 });
@@ -35,8 +35,7 @@ export async function POST(req: Request) {
 
     return NextResponse.json({ 
       tree, 
-      provider: resolvedProvider,
-      filters: { maxDepth, excludePatterns }
+      provider: resolvedProvider
     });
   } catch (error) {
     console.error('[API/TREE]', error);

--- a/src/hooks/use-repo-tree-generator-state.ts
+++ b/src/hooks/use-repo-tree-generator-state.ts
@@ -206,9 +206,7 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ 
             url: effectiveUrl, 
-            providerType: repoType,
-            maxDepth,
-            excludePatterns: excludePatternsInput.split(',').map(p => p.trim()).filter(Boolean)
+            providerType: repoType
           }),
         });
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed unused filter fields from the tree API to simplify the contract and reduce payload size. The client no longer sends `maxDepth` or `excludePatterns`, and the server no longer returns them.

- **Refactors**
  - API: stop parsing and returning `maxDepth` and `excludePatterns` in `src/app/api/tree/route.ts`.
  - Client: stop sending these fields in `useRepoTreeGeneratorState`.

<sup>Written for commit d38f8cfab720408028872398415ec91225c90499. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

