### PR TITLE
feat(tree-customization): add sort order, hidden files toggle, include patterns, and focus path

### DIFF
--- a/src/app/generator/customization-options.tsx
+++ b/src/app/generator/customization-options.tsx
@@ -4,7 +4,8 @@ import type React from 'react';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
-import type { TreeCustomizationOptions } from '@/types/tree-customization';
+import { Input } from '@/components/ui/input';
+import type { TreeCustomizationOptions, SortOrder } from '@/types/tree-customization';
 
 interface Props {
   options: TreeCustomizationOptions;
@@ -14,7 +15,6 @@ interface Props {
 const CustomizationOptions: React.FC<Props> = ({ options, onChange }) => {
   return (
     <div className="space-y-4 py-1">
-      {/* ASCII Style */}
       <div className="flex items-center justify-between">
         <Label htmlFor="ascii-style" className="text-sm">ASCII style</Label>
         <Select
@@ -32,13 +32,52 @@ const CustomizationOptions: React.FC<Props> = ({ options, onChange }) => {
         </Select>
       </div>
 
-      {/* Options list */}
+      <div className="flex items-center justify-between">
+        <Label htmlFor="sort-order" className="text-sm">Sort order</Label>
+        <Select
+          value={options.sortOrder}
+          onValueChange={(v) => onChange({ sortOrder: v as SortOrder })}
+        >
+          <SelectTrigger className="w-36 h-8 text-sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="default">Dirs first (A–Z)</SelectItem>
+            <SelectItem value="name-asc">Name (A–Z)</SelectItem>
+            <SelectItem value="name-desc">Name (Z–A)</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="focus-path" className="text-sm">Focus path</Label>
+        <Input
+          id="focus-path"
+          value={options.focusPath}
+          onChange={(e) => onChange({ focusPath: e.target.value })}
+          placeholder="e.g., src/, packages/ui"
+          className="h-8 text-sm"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="include-patterns" className="text-sm">Include patterns</Label>
+        <Input
+          id="include-patterns"
+          value={options.includePatterns}
+          onChange={(e) => onChange({ includePatterns: e.target.value })}
+          placeholder="e.g., *.ts, src, components"
+          className="h-8 text-sm"
+        />
+      </div>
+
       {([
         { id: 'useIcons', label: 'Use icons', note: 'Both views' },
         { id: 'showLineNumbers', label: 'Line numbers', note: 'ASCII only' },
         { id: 'showDescriptions', label: 'Descriptions', note: 'ASCII only' },
         { id: 'showRootDirectory', label: 'Root folder name', note: 'ASCII only' },
         { id: 'showTrailingSlash', label: 'Trailing slash', note: 'ASCII only' },
+        { id: 'hideHiddenFiles', label: 'Hide hidden files', note: 'All views' },
       ] as const).map(({ id, label, note }) => (
         <div key={id} className="flex items-center justify-between">
           <div>

--- a/src/components/interactive-tree-view.tsx
+++ b/src/components/interactive-tree-view.tsx
@@ -64,6 +64,27 @@ const getFileIcon = (filename: string) => {
   }
 };
 
+const sortEntries = (
+  entries: [string, DirectoryMap | { type: 'file' }][],
+  sortOrder: TreeCustomizationOptions['sortOrder']
+): [string, DirectoryMap | { type: 'file' }][] => {
+  return [...entries].sort(([keyA, valueA], [keyB, valueB]) => {
+    const isDirA = valueA instanceof Map;
+    const isDirB = valueB instanceof Map;
+
+    if (sortOrder === 'default') {
+      if (isDirA !== isDirB) return isDirA ? -1 : 1;
+      return keyA.localeCompare(keyB);
+    }
+
+    if (sortOrder === 'name-asc') {
+      return keyA.localeCompare(keyB);
+    }
+
+    return keyB.localeCompare(keyA);
+  });
+};
+
 interface TreeNodeProps {
   name: string;
   content: DirectoryMap | { type: 'file' };
@@ -74,6 +95,7 @@ interface TreeNodeProps {
 const TreeNode: React.FC<TreeNodeProps> = ({ name, content, depth, customizationOptions }) => {
   const [isExpanded, setIsExpanded] = useState(depth < 2);
   const isFolder = content instanceof Map;
+  const sortOrder = customizationOptions.sortOrder ?? 'default';
 
   const getIndentClass = () => `tree-node-depth-${Math.min(depth, 8)}`;
 
@@ -101,13 +123,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({ name, content, depth, customization
         </div>
 
         <div style={{ height: isExpanded ? 'auto' : 0, overflow: 'hidden' }}>
-          {isExpanded && Array.from(content.entries())
-            .sort(([a, va], [b, vb]) => {
-              const aDir = va instanceof Map;
-              const bDir = vb instanceof Map;
-              if (aDir !== bDir) return aDir ? -1 : 1;
-              return a.localeCompare(b);
-            })
+          {isExpanded && sortEntries(Array.from(content.entries()), sortOrder)
             .map(([childName, childContent]) => (
               <TreeNode
                 key={childName}
@@ -149,15 +165,11 @@ const InteractiveTreeView: React.FC<Props> = ({ structure, customizationOptions 
     );
   }
 
+  const sortOrder = customizationOptions.sortOrder ?? 'default';
+
   return (
     <div className="tree-container">
-      {Array.from(structure.entries())
-        .sort(([a, va], [b, vb]) => {
-          const aDir = va instanceof Map;
-          const bDir = vb instanceof Map;
-          if (aDir !== bDir) return aDir ? -1 : 1;
-          return a.localeCompare(b);
-        })
+      {sortEntries(Array.from(structure.entries()), sortOrder)
         .map(([name, content]) => (
           <TreeNode
             key={name}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -27,10 +27,10 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { overlayClassName?: string }
+>(({ className, children, overlayClassName, ...props }, ref) => (
   <DialogPortal>
-    <DialogOverlay />
+    <DialogOverlay className={overlayClassName} />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(

--- a/src/hooks/use-repo-tree-generator-state.ts
+++ b/src/hooks/use-repo-tree-generator-state.ts
@@ -15,6 +15,7 @@ import {
   countEntries,
   FilterOptions,
   filterTreeEntries,
+  sortTreeEntries,
 } from '@/lib/repo-tree-utils';
 import { convertMapToJson } from '@/lib/utils';
 import type { TreeCustomizationOptions } from '@/types/tree-customization';
@@ -36,13 +37,33 @@ const DEFAULT_OPTIONS: TreeCustomizationOptions = {
   showDescriptions: false,
   showRootDirectory: false,
   showTrailingSlash: false,
+  sortOrder: 'default',
+  hideHiddenFiles: false,
+  includePatterns: '',
+  focusPath: '',
 };
 
 const loadOptions = (): TreeCustomizationOptions => {
   if (typeof window === 'undefined') return DEFAULT_OPTIONS;
   try {
     const saved = localStorage.getItem('treeCustomizationOptions');
-    if (saved) return { ...DEFAULT_OPTIONS, ...JSON.parse(saved) };
+    if (saved) {
+      const parsed = JSON.parse(saved);
+      const migrated: TreeCustomizationOptions = {
+        ...DEFAULT_OPTIONS,
+        asciiStyle: parsed.asciiStyle ?? DEFAULT_OPTIONS.asciiStyle,
+        useIcons: parsed.useIcons ?? DEFAULT_OPTIONS.useIcons,
+        showLineNumbers: parsed.showLineNumbers ?? DEFAULT_OPTIONS.showLineNumbers,
+        showDescriptions: parsed.showDescriptions ?? DEFAULT_OPTIONS.showDescriptions,
+        showRootDirectory: parsed.showRootDirectory ?? DEFAULT_OPTIONS.showRootDirectory,
+        showTrailingSlash: parsed.showTrailingSlash ?? DEFAULT_OPTIONS.showTrailingSlash,
+        sortOrder: parsed.sortOrder ?? DEFAULT_OPTIONS.sortOrder,
+        hideHiddenFiles: parsed.showHiddenFiles === false || DEFAULT_OPTIONS.hideHiddenFiles,
+        includePatterns: parsed.includePatterns ?? DEFAULT_OPTIONS.includePatterns,
+        focusPath: parsed.focusPath ?? DEFAULT_OPTIONS.focusPath,
+      };
+      return migrated;
+    }
   } catch {
     // ignore
   }
@@ -66,7 +87,6 @@ export interface RepoTreeGeneratorState {
   repoType: ProviderType;
   setRepoType: (type: ProviderType) => void;
   structureMap: DirectoryMap;
-  setStructureMap: (map: DirectoryMap) => void;
   loading: boolean;
   validation: ValidationError;
   setValidation: (v: ValidationError) => void;
@@ -124,10 +144,8 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
   const [sourceTab, setSourceTab] = useState<SourceTab>('url');
   const [repoUrl, setRepoUrl] = useState('');
   const [repoType, setRepoType] = useState<ProviderType>('github');
-  const [structureMap, setStructureMap] = useState<DirectoryMap>(new Map());
   const [loading, setLoading] = useState(false);
   const [validation, setValidation] = useState<ValidationError>({ message: '', isError: false });
-  const [repoValidation, setRepoValidation] = useState<RepoValidationResult | null>(null);
   const [showValidationDialog, setShowValidationDialog] = useState(false);
   const [allowLargeRepo, setAllowLargeRepo] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -137,18 +155,54 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
   const [showDownloadMenu, setShowDownloadMenu] = useState(false);
   const [showExportImageMenu, setShowExportImageMenu] = useState(false);
   const [customizationOptions, setCustomizationOptions] = useState<TreeCustomizationOptions>(loadOptions());
-  const [fileTypeData, setFileTypeData] = useState<{ name: string; value: number }[]>([]);
-  const [languageData, setLanguageData] = useState<{ name: string; percentage: number }[]>([]);
   const [selectedRepoName, setSelectedRepoName] = useState<string | null>(null);
   const [showStarNote, setShowStarNote] = useState(false);
   const [maxDepth, setMaxDepth] = useState<number | null>(null);
   const [excludePatternsInput, setExcludePatternsInput] = useState('');
   const [rawTree, setRawTree] = useState<TreeItem[]>([]);
-  const [filteredTree, setFilteredTree] = useState<TreeItem[]>([]);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const outputRef = useRef<HTMLDivElement>(null);
   const requestIdRef = useRef(0);
+
+  const excludePatternsList = useMemo(
+    () => excludePatternsInput.split(',').map(p => p.trim()).filter(Boolean),
+    [excludePatternsInput]
+  );
+
+  const includePatternsList = useMemo(
+    () => customizationOptions.includePatterns.split(',').map(p => p.trim()).filter(Boolean),
+    [customizationOptions.includePatterns]
+  );
+
+  const filterOptions = useMemo<FilterOptions>(() => ({
+    maxDepth,
+    excludePatterns: excludePatternsList,
+    includePatterns: includePatternsList,
+    focusPath: customizationOptions.focusPath || null,
+    hideHiddenFiles: customizationOptions.hideHiddenFiles,
+    sortOrder: customizationOptions.sortOrder,
+  }), [maxDepth, excludePatternsList, includePatternsList, customizationOptions.focusPath, customizationOptions.hideHiddenFiles, customizationOptions.sortOrder]);
+
+  const filteredTree = useMemo(() => {
+    if (rawTree.length === 0) return [];
+    return sortTreeEntries(filterTreeEntries(rawTree, filterOptions), filterOptions.sortOrder);
+  }, [rawTree, filterOptions]);
+
+  const structureMap = useMemo(() => {
+    if (rawTree.length === 0) return new Map() as DirectoryMap;
+    return generateStructure(rawTree, filterOptions);
+  }, [rawTree, filterOptions]);
+
+  const repoValidation = useMemo(() => {
+    if (filteredTree.length === 0) return null;
+    return validateRepositoryStructure(filteredTree);
+  }, [filteredTree]);
+
+  const { fileTypes: fileTypeData, languages: languageData } = useMemo(() => {
+    if (structureMap.size === 0) return { fileTypes: [], languages: [] };
+    return analyzeRepository(structureMap);
+  }, [structureMap]);
 
   useEffect(() => {
     if (isAuthenticated) setSourceTab('my-repos');
@@ -228,33 +282,19 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
         if (currentRequestId !== requestIdRef.current) return;
 
         setRawTree(tree);
-
-        const excludePatterns = excludePatternsInput.split(',').map(p => p.trim()).filter(Boolean);
-        const filterOptions: FilterOptions = {
-          maxDepth,
-          excludePatterns
-        };
         
-        const filtered = filterTreeEntries(tree, filterOptions);
-        setFilteredTree(filtered);
-
-        const repoVal = validateRepositoryStructure(filtered);
-        setRepoValidation(repoVal);
-
-        if (!skipValidation && !allowLargeRepo && (!repoVal.isValid || repoVal.warnings.length > 0)) {
+        const filteredForValidation = sortTreeEntries(filterTreeEntries(tree, filterOptions), filterOptions.sortOrder);
+        const validationResult = validateRepositoryStructure(filteredForValidation);
+        
+        if (!allowLargeRepo && (!validationResult.isValid || validationResult.warnings.length > 0)) {
           setShowValidationDialog(true);
           setLoading(false);
           return;
         }
-
-        const map = generateStructure(tree, filterOptions);
-        setStructureMap(map);
+        
         setValidation({ message: '', isError: false });
         localStorage.setItem('lastRepoUrl', effectiveUrl);
 
-        const { fileTypes, languages } = analyzeRepository(map);
-        setFileTypeData(fileTypes);
-        setLanguageData(languages);
         setShowValidationDialog(false);
 
         setTimeout(() => outputRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' }), 150);
@@ -265,7 +305,6 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
           message: err instanceof Error ? err.message : 'Failed to fetch repository',
           isError: true,
         });
-        setRepoValidation(null);
         setShowStarNote(false);
       } finally {
         if (currentRequestId === requestIdRef.current) {
@@ -273,48 +312,16 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
         }
       }
     },
-    [repoUrl, repoType, validateUrl, maxDepth, excludePatternsInput, allowLargeRepo]
+    [repoUrl, repoType, validateUrl, filterOptions, allowLargeRepo]
   );
 
   const handleValidateAndGenerate = useCallback(
     async () => {
-      if (filteredTree.length === 0 && rawTree.length > 0) {
-        const excludePatterns = excludePatternsInput.split(',').map(p => p.trim()).filter(Boolean);
-        const filterOptions: FilterOptions = {
-          maxDepth,
-          excludePatterns
-        };
-        
-        const filtered = filterTreeEntries(rawTree, filterOptions);
-        setFilteredTree(filtered);
-        
-        const repoVal = validateRepositoryStructure(filtered);
-        setRepoValidation(repoVal);
-
-        const map = generateStructure(rawTree, filterOptions);
-        setStructureMap(map);
-        setValidation({ message: '', isError: false });
-
-        const { fileTypes, languages } = analyzeRepository(map);
-        setFileTypeData(fileTypes);
-        setLanguageData(languages);
-        setShowValidationDialog(false);
-
-        setTimeout(() => outputRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' }), 150);
-      } else if (filteredTree.length > 0) {
-        const map = generateStructure(rawTree, {
-          maxDepth,
-          excludePatterns: excludePatternsInput.split(',').map(p => p.trim()).filter(Boolean)
-        });
-        setStructureMap(map);
-        setShowValidationDialog(false);
-        
-        const { fileTypes, languages } = analyzeRepository(map);
-        setFileTypeData(fileTypes);
-        setLanguageData(languages);
+      if (!allowLargeRepo && repoValidation && (!repoValidation.isValid || repoValidation.warnings.length > 0)) {
+        setShowValidationDialog(true);
       }
     },
-    [filteredTree, rawTree, maxDepth, excludePatternsInput]
+    [repoValidation, allowLargeRepo]
   );
 
   const handleRepoSelect = useCallback(
@@ -323,11 +330,8 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
       setRepoType(provider as ProviderType);
       const parts = url.replace(/\/$/, '').split('/');
       setSelectedRepoName(parts[parts.length - 1]);
-      setStructureMap(new Map());
       setRawTree([]);
-      setFilteredTree([]);
       setValidation({ message: '', isError: false });
-      setRepoValidation(null);
       setSearchTerm('');
       setAllowLargeRepo(false);
       handleFetchStructure(url, false);
@@ -375,8 +379,7 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
     setRepoUrl('');
     setSelectedRepoName(null);
     localStorage.removeItem('lastRepoUrl');
-    setStructureMap(new Map());
-    setRepoValidation(null);
+    setRawTree([]);
     setValidation({ message: '', isError: false });
     setShowStarNote(false);
     setAllowLargeRepo(false);
@@ -563,7 +566,6 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
     repoType,
     setRepoType,
     structureMap,
-    setStructureMap,
     loading,
     validation,
     setValidation,
@@ -601,7 +603,7 @@ export function useRepoTreeGeneratorState(isAuthenticated: boolean): RepoTreeGen
     filteredTree,
     maxDepth,
     setMaxDepth,
-    excludePatterns: excludePatternsInput.split(',').map(p => p.trim()).filter(Boolean),
+    excludePatterns: excludePatternsList,
     setExcludePatterns: (patterns: string[]) => setExcludePatternsInput(patterns.join(', ')),
     excludePatternsInput,
     setExcludePatternsInput,

--- a/src/lib/repo-tree-utils.ts
+++ b/src/lib/repo-tree-utils.ts
@@ -225,8 +225,17 @@ export const buildStructureString = (
   const sorted = [...entries].sort(([keyA, valueA], [keyB, valueB]) => {
     const isDirA = valueA instanceof Map;
     const isDirB = valueB instanceof Map;
-    if (isDirA !== isDirB) return isDirA ? -1 : 1;
-    return keyA.localeCompare(keyB);
+    
+    if (customizationOptions.sortOrder === 'default') {
+      if (isDirA !== isDirB) return isDirA ? -1 : 1;
+      return keyA.localeCompare(keyB);
+    }
+    
+    if (customizationOptions.sortOrder === 'name-asc') {
+      return keyA.localeCompare(keyB);
+    }
+    
+    return keyB.localeCompare(keyA);
   });
 
   for (let i = 0; i < sorted.length; i++) {
@@ -318,6 +327,10 @@ export const countEntries = (map: DirectoryMap): EntryCounts => {
 export interface FilterOptions {
   maxDepth: number | null;
   excludePatterns: string[];
+  includePatterns: string[];
+  focusPath: string | null;
+  hideHiddenFiles: boolean;
+  sortOrder: 'default' | 'name-asc' | 'name-desc';
 }
 
 export const getPathDepth = (path: string): number => {
@@ -332,7 +345,7 @@ const globToRegex = (pattern: string): RegExp => {
   return new RegExp(`^${escaped}$`, 'i');
 };
 
-export const matchesExclude = (path: string, patterns: string[]): boolean => {
+export const matchesPattern = (path: string, patterns: string[]): boolean => {
   if (patterns.length === 0) return false;
 
   const segments = path.split('/');
@@ -357,19 +370,45 @@ export const matchesExclude = (path: string, patterns: string[]): boolean => {
   return false;
 };
 
+export const matchesInclude = (path: string, patterns: string[]): boolean => {
+  if (patterns.length === 0) return true;
+  return matchesPattern(path, patterns);
+};
+
+export const matchesExclude = (path: string, patterns: string[]): boolean => {
+  if (patterns.length === 0) return false;
+  return matchesPattern(path, patterns);
+};
+
+const isHiddenEntry = (path: string): boolean => {
+  const segments = path.split('/').filter(Boolean);
+  return segments.some((seg) => seg.startsWith('.'));
+};
+
 export const filterTreeEntries = (
   tree: TreeItem[],
   options: FilterOptions
 ): TreeItem[] => {
-  const { maxDepth, excludePatterns } = options;
+  const { maxDepth, excludePatterns, includePatterns, focusPath, hideHiddenFiles } = options;
 
-  if (maxDepth === null && (!excludePatterns || excludePatterns.length === 0)) {
+  const hasFilters =
+    maxDepth !== null ||
+    (excludePatterns && excludePatterns.length > 0) ||
+    (includePatterns && includePatterns.length > 0) ||
+    focusPath !== null ||
+    hideHiddenFiles;
+
+  if (!hasFilters) {
     return tree;
   }
 
-  const excludedDirs = new Set<string>();
+  const focusPathParts = focusPath ? focusPath.split('/').filter(Boolean) : null;
+  const focusPathDepth = focusPath ? focusPathParts!.length : 0;
 
-  if (excludePatterns.length > 0) {
+  const excludedDirs = new Set<string>();
+  const includedDirs = new Set<string>();
+
+  if (excludePatterns && excludePatterns.length > 0) {
     for (const item of tree) {
       if (item.type === 'tree' && matchesExclude(item.path, excludePatterns)) {
         excludedDirs.add(item.path);
@@ -377,8 +416,37 @@ export const filterTreeEntries = (
     }
   }
 
+  if (includePatterns && includePatterns.length > 0) {
+    for (const item of tree) {
+      if (matchesInclude(item.path, includePatterns)) {
+        const parts = item.path.split('/').filter(Boolean);
+        for (let i = 1; i <= parts.length; i++) {
+          includedDirs.add(parts.slice(0, i).join('/'));
+        }
+      }
+    }
+  }
+
   return tree.filter((item) => {
-    if (excludePatterns.length > 0) {
+    if (focusPath !== null) {
+      const itemParts = item.path.split('/').filter(Boolean);
+      if (focusPathParts) {
+        const match = focusPathParts.every((part, i) => itemParts[i] === part);
+        if (!match && item.path !== focusPath) {
+          return false;
+        }
+      }
+    }
+
+    if (includePatterns && includePatterns.length > 0) {
+      if (!matchesInclude(item.path, includePatterns)) {
+        if (!includedDirs.has(item.path)) {
+          return false;
+        }
+      }
+    }
+
+    if (excludePatterns && excludePatterns.length > 0) {
       if (matchesExclude(item.path, excludePatterns)) {
         return false;
       }
@@ -392,11 +460,38 @@ export const filterTreeEntries = (
       }
     }
 
-    if (maxDepth !== null && getPathDepth(item.path) > maxDepth) {
+    if (hideHiddenFiles && isHiddenEntry(item.path)) {
       return false;
     }
 
+    if (maxDepth !== null) {
+      const itemDepth = focusPath !== null
+        ? item.path.split('/').filter(Boolean).length - focusPathDepth
+        : getPathDepth(item.path);
+      if (itemDepth > maxDepth) {
+        return false;
+      }
+    }
+
     return true;
+  });
+};
+
+export const sortTreeEntries = (
+  items: TreeItem[],
+  sortOrder: 'default' | 'name-asc' | 'name-desc'
+): TreeItem[] => {
+  return [...items].sort((a, b) => {
+    if (sortOrder === 'default') {
+      const aIsDir = a.type === 'tree';
+      const bIsDir = b.type === 'tree';
+      if (aIsDir !== bIsDir) return aIsDir ? -1 : 1;
+      return a.path.localeCompare(b.path);
+    }
+    if (sortOrder === 'name-asc') {
+      return a.path.localeCompare(b.path);
+    }
+    return b.path.localeCompare(a.path);
   });
 };
 

--- a/src/types/tree-customization.ts
+++ b/src/types/tree-customization.ts
@@ -1,3 +1,5 @@
+export type SortOrder = 'default' | 'name-asc' | 'name-desc';
+
 export interface TreeCustomizationOptions {
   asciiStyle: 'basic' | 'detailed' | 'minimal';
   useIcons: boolean;
@@ -5,6 +7,10 @@ export interface TreeCustomizationOptions {
   showDescriptions: boolean;
   showRootDirectory: boolean;
   showTrailingSlash: boolean;
+  sortOrder: SortOrder;
+  hideHiddenFiles: boolean;
+  includePatterns: string;
+  focusPath: string;
 }
 
 export type DirectoryEntry = { type: 'file' } | DirectoryMap;


### PR DESCRIPTION
Adds advanced customization options, including sort order, hidden files toggle, include patterns, and focus path to improve control over repository output and filtering across ASCII and interactive views.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds new tree customization controls: sort order, hide hidden files, include patterns, and focus path across ASCII and interactive views. Centralizes filter/sort logic and memoizes state for consistent output and faster UI.

- **New Features**
  - Sort order: default (dirs first), name A–Z, name Z–A.
  - Toggle to hide dotfiles.
  - Include patterns input (glob-like) to whitelist paths.
  - Focus path to scope the tree; depth is relative to that root.
  - Persists options in localStorage with backward-compatible migration.

- **Refactors**
  - Unified pipeline in `repo-tree-utils` (`filterTreeEntries`, `sortTreeEntries`); `FilterOptions` now includes include patterns, focus path, hidden toggle, and sort order.
  - `use-repo-tree-generator-state` derives `filteredTree` and `structureMap` via `useMemo`; removes mutable `setStructureMap`; simplified validation flow.
  - Interactive view uses shared sorting; ASCII builder respects selected sort order.
  - `DialogContent` accepts `overlayClassName` to style the overlay.

<sup>Written for commit 80a7c31bbcd3ddbbe9997f9df30a871209b5b9d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

